### PR TITLE
Rip out NumPy and replace with small vector class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,6 @@ setup(name='shaape',
       requires=[
           'networkx',
           'cairo',
-          'scipy',
-          'numpy',
-          'PIL',
           'yaml',
           'pango',
           'pangocairo']

--- a/shaape/cairobackend.py
+++ b/shaape/cairobackend.py
@@ -2,8 +2,6 @@ import cairo
 import os
 import errno
 import math
-import numpy as np
-from scipy import ndimage
 from drawingbackend import DrawingBackend
 import networkx as nx
 from translatable import Translatable
@@ -28,22 +26,28 @@ class CairoBackend(DrawingBackend):
         return
 
     def blur_surface(self):
-        blurred_surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, int(math.ceil(self.__image_size[0])), int(math.ceil(self.__image_size[1])))
-        top_surface = self.__surfaces[-1]
-        width = top_surface.get_width()
-        height = top_surface.get_height()
-        src = np.frombuffer(top_surface.get_data(), np.uint8)
-        src.shape = (height, width, 4)
-        dst = np.frombuffer(blurred_surface.get_data(), np.uint8)
-        dst.shape = (height, width, 4)
-        dst[:,:,3] = ndimage.gaussian_filter(src[:,:,3], sigma=3 * self.scale())
-        dst[:,:,0] = ndimage.gaussian_filter(src[:,:,0], sigma=3 * self.scale())
-        dst[:,:,1] = ndimage.gaussian_filter(src[:,:,1], sigma=3 * self.scale())
-        dst[:,:,2] = ndimage.gaussian_filter(src[:,:,2], sigma=3 * self.scale())
-        blurred_image = cairo.ImageSurface.create_for_data(dst, cairo.FORMAT_ARGB32, width, height)
-        self.__ctx.set_source_surface(blurred_image)
-        self.__ctx.set_operator(cairo.OPERATOR_SOURCE)
-        self.__ctx.paint()
+        try:
+            import numpy as np
+            from scipy import ndimage
+
+            blurred_surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, int(math.ceil(self.__image_size[0])), int(math.ceil(self.__image_size[1])))
+            top_surface = self.__surfaces[-1]
+            width = top_surface.get_width()
+            height = top_surface.get_height()
+            src = np.frombuffer(top_surface.get_data(), np.uint8)
+            src.shape = (height, width, 4)
+            dst = np.frombuffer(blurred_surface.get_data(), np.uint8)
+            dst.shape = (height, width, 4)
+            dst[:,:,3] = ndimage.gaussian_filter(src[:,:,3], sigma=3 * self.scale())
+            dst[:,:,0] = ndimage.gaussian_filter(src[:,:,0], sigma=3 * self.scale())
+            dst[:,:,1] = ndimage.gaussian_filter(src[:,:,1], sigma=3 * self.scale())
+            dst[:,:,2] = ndimage.gaussian_filter(src[:,:,2], sigma=3 * self.scale())
+            blurred_image = cairo.ImageSurface.create_for_data(dst, cairo.FORMAT_ARGB32, width, height)
+            self.__ctx.set_source_surface(blurred_image)
+            self.__ctx.set_operator(cairo.OPERATOR_SOURCE)
+            self.__ctx.paint()
+        except ImportError:
+            pass
 
     def new_surface(self, name = None):
         return cairo.ImageSurface(cairo.FORMAT_ARGB32, int(math.ceil(self.image_size()[0])), int(math.ceil(self.image_size()[1])))

--- a/shaape/graphalgorithms.py
+++ b/shaape/graphalgorithms.py
@@ -1,6 +1,6 @@
 import networkx as nx
-import numpy as np
 import math
+import vector
 
 def reduce_path(nodes):
     new_nodes = []
@@ -41,25 +41,19 @@ def has_same_direction(v1, v2):
         return False
 
 def right_angle(v1, v2):
-    x = np.array([v1[0], v1[1]])
-    y = np.array([v2[0], v2[1]])
-    cross = np.cross(x, y)
-    dot = np.dot(x, y)
-    x_length = np.sqrt((x * x).sum())
-    y_length = np.sqrt((y * y).sum())
-    _angle = np.arccos(dot / x_length / y_length)
+    x = vector.Vector(v1[0], v1[1])
+    y = vector.Vector(v2[0], v2[1])
+    dot = vector.dot(x, y)
+    _angle = math.acos(dot / x.length() / y.length())
     if x[0] * y[1] < y[0] * x[1]:
         _angle = 2 * math.pi - _angle
     return _angle
 
 def angle(v1, v2):
-    x = np.array([v1[0], v1[1]])
-    y = np.array([v2[0], v2[1]])
-    cross = np.cross(x, y)
-    dot = np.dot(x, y)
-    x_length = np.sqrt((x * x).sum())
-    y_length = np.sqrt((y * y).sum())
-    _angle = np.arccos(dot / x_length / y_length) / math.pi * 180
+    x = vector.Vector(v1[0], v1[1])
+    y = vector.Vector(v2[0], v2[1])
+    dot = vector.dot(x, y)
+    _angle = math.acos(dot / x.length() / y.length()) / math.pi * 180
     return _angle
 
 def is_chord_free(_graph, _cycle):
@@ -159,37 +153,33 @@ def ccw(a, b, c):
 def line_segments_intersect(seg1, seg2):
     return ccw(seg1[0], seg2[0], seg2[1]) != ccw(seg1[1], seg2[0], seg2[1]) and ccw(seg1[0], seg1[1], seg2[0]) != ccw(seg1[0], seg1[1], seg2[1])
 
-def vector_length(v):
-    return np.sqrt(v.dot(v))
-
-def vector_length_squared(v):
-    return v.dot(v)
-
 def point_point_distance(p1, p2):
-    p1 = np.array(p1)
-    p2 = np.array(p2)
+    p1 = vector.Vector(p1)
+    p2 = vector.Vector(p2)
     if p1 == p2:
         return 0
     else:
-       return vector_length(p2 - p1)
+       return (p2 - p1).length()
 
 def line_segment_point_distance(point, seg):
-    seg_start = np.array(seg[0])
-    seg_end = np.array(seg[1])
-    point = np.array(tuple(point))
-    seg_dir = seg_end - seg_start
-    seg_length = vector_length_squared(seg_dir)
-    if seg_length == 0:
-      return vector_length(point - seg_start)
+    seg_start = vector.Vector(seg[0][0], seg[0][1])
+    seg_end = vector.Vector(seg[1][0], seg[1][1])
+    x, y = point
+    point = vector.Vector(x, y)
 
-    t = np.dot(point - seg_start, seg_dir) / seg_length
+    seg_dir = seg_end - seg_start
+    seg_length = seg_dir.length()**2
+    if seg_length == 0:
+      return (point - seg_start).length()
+
+    t = vector.dot(point - seg_start, seg_dir) / seg_length
     if t < 0:
-      return vector_length(point - seg_start)
+      return (point - seg_start).length()
     elif t > 1:
-      return vector_length(point - seg_end)
+      return (point - seg_end).length()
 
     projection = seg_start + t * seg_dir
-    return vector_length(point - projection)
+    return (point - projection).length()
 
 def line_segments_distance(seg1, seg2):
     if line_segments_intersect(seg1, seg2):

--- a/shaape/text.py
+++ b/shaape/text.py
@@ -2,7 +2,8 @@ from drawable import Drawable
 from translatable import Translatable
 from scalable import Scalable
 from named import Named
-import numpy as np
+from vector import Vector
+
 
 class Text(Drawable, Translatable, Scalable, Named):
     def __init__(self, text = "", position = (0, 0)):
@@ -11,7 +12,7 @@ class Text(Drawable, Translatable, Scalable, Named):
         Named.__init__(self)
         self.__text = text
         self.__font_size = 1
-        self.__scaled_direction = np.array([1, 0])
+        self.__scaled_direction = Vector(1, 0)
         return
 
     def text(self):
@@ -23,17 +24,17 @@ class Text(Drawable, Translatable, Scalable, Named):
     def scale(self, scale):
         Translatable.scale(self, scale)
         self.__font_size = self.__font_size * scale[0]
-        self.__scaled_direction = (self.__scaled_direction[0] * scale[0], self.__scaled_direction[1] * scale[1])
+        self.__scaled_direction *= scale
         return
     
     def min(self):
         return self.position()
 
     def max(self):
-        return tuple(np.array(self.position()) + np.array(self.__scaled_direction) * len(self.__text))
+        return self.position() + self.__scaled_direction * len(self.__text)
 
     def anchor(self):
-        return np.array(self.position()) + np.array([0.5, 0.5])
+        return self.position() * 0.5
 
     def letter_position(self, index):
         if index < len(self.__text):

--- a/shaape/translatable.py
+++ b/shaape/translatable.py
@@ -1,16 +1,19 @@
+from vector import Vector
+
+
 class Translatable(object):
     def __init__(self, position = (0, 0)):
-        self.__position = position
+        self.__position = Vector(position[0], position[1])
 
     def set_position(self, position):
-        self.__position = position
+        self.__position = Vector(position[0], position[1])
 
     def position(self):
         return self.__position
 
     def translate(self, diff):
-        self.__position = (self.__position[0] + diff[0], self.__position[1] + diff[1])
+        self.__position += diff
 
     def scale(self, scale):
-        self.__position = (self.__position[0] * scale[0], self.__position[1] * scale[1])
+        self.__position *= scale
         return

--- a/shaape/vector.py
+++ b/shaape/vector.py
@@ -3,6 +3,7 @@ import math
 
 _number_types = (int, long, float)
 
+
 class Vector(object):
     def __init__(self, x=0.0, y=0.0):
         self.x, self.y = float(x), float(y)

--- a/shaape/vector.py
+++ b/shaape/vector.py
@@ -1,0 +1,64 @@
+import math
+
+
+_number_types = (int, long, float)
+
+class Vector(object):
+    def __init__(self, x=0.0, y=0.0):
+        self.x, self.y = float(x), float(y)
+
+    def __eq__(self, other):
+        return self.x == other[0] and self.y == other[1]
+
+    def __add__(self, other):
+        return Vector(self.x + other[0], self.y + other[1])
+
+    def __iadd__(self, other):
+        self.x += other[0]
+        self.y += other[1]
+        return self
+
+    def __sub__(self, other):
+        return Vector(self.x - other[0], self.y - other[1])
+
+    def __isub__(self, other):
+        self.x -= other[0]
+        self.y -= other[1]
+        return self
+
+    def __mul__(self, other):
+        if type(other) in _number_types:
+            return Vector(self.x * other, self.y * other)
+
+        return Vector(self.x * other[0], self.y * other[1])
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+    def __imul__(self, other):
+        if type(other) in _number_types:
+            self.x *= other
+            self.y *= other
+        else:
+            self.x *= other[0]
+            self.y *= other[1]
+        return self
+
+    def __idiv__(self, scalar):
+        self.x /= scalar
+        self.y /= scalar
+        return self
+
+    def __getitem__(self, key):
+        if key == 0:
+            return self.x
+        if key == 1:
+            return self.y
+        raise IndexError("{0} is neither 0 nor 1".format(key))
+
+    def length(self):
+        return math.sqrt(self.x**2 + self.y**2)
+
+
+def dot(vec_a, vec_b):
+    return vec_a.x * vec_b.x + vec_a.y * vec_b.y


### PR DESCRIPTION
This change removes NumPy and makes blurring with SciPy optional.

Here's my rationale:
- NumPy and SciPy are pretty huge
- I want to run Shaape on small machines such as the RaspberryPi from source
- NumPy wasn't even used that heavily

All the tests succeed, except for one where a generated image was committed. It might make also sense to adapt the `Node` class.
